### PR TITLE
Strip unwanted characters from the ISBN

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -22,7 +22,7 @@ class BooksController < ApplicationController
   end
 
   def lookup_isbn
-    isbn = params[:isbn].strip
+    isbn = params[:isbn].strip.gsub(/\-/, "")
     not_found if isbn.blank?
 
     metadata = BookMetadataLookup.find_by_isbn(isbn.to_s)

--- a/test/functional/books_controller_test.rb
+++ b/test/functional/books_controller_test.rb
@@ -76,6 +76,13 @@ class BooksControllerTest < ActionController::TestCase
       get :lookup_isbn, :isbn => "12345"
       assert_response :success
     end
+
+    should "be forgiving of the input" do
+      BookMetadataLookup.expects(:find_by_isbn).with("12345").returns({})
+
+      get :lookup_isbn, :isbn => "123-4-5"
+      assert_response :success
+    end
   end
 
   context "a single book" do


### PR DESCRIPTION
Allow people to enter with or without hyphens.
